### PR TITLE
お店の写真をsmallUrl -> largeUrlの順で読み込むようにする

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -62,10 +62,7 @@ class ShopDetail extends StatelessWidget {
       removeTop: true,
       child: ListView(
         children: <Widget>[
-          SizedBox(
-            height: 320,
-            child: _imageFor(shop.thumbnail),
-          ),
+          _imageFor(shop.thumbnail),
           SizedBox(
             height: 220,
             child: ListView(

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -45,6 +45,16 @@ class ShopDetail extends StatelessWidget {
     }
   }
 
+  FadeInImage _imageFor(Picture picture) {
+    return FadeInImage(
+      placeholder: NetworkImage(picture.smallUrl),
+      image: NetworkImage(picture.largeUrl),
+      fadeOutDuration: Duration(milliseconds: 30),
+      fadeInDuration: Duration(milliseconds: 600),
+      fit: BoxFit.cover,
+    );
+  }
+
   @override
   Widget build(BuildContext context) {
     return MediaQuery.removePadding(
@@ -52,7 +62,10 @@ class ShopDetail extends StatelessWidget {
       removeTop: true,
       child: ListView(
         children: <Widget>[
-          Image.network(shop.thumbnail.largeUrl),
+          SizedBox(
+            height: 320,
+            child: _imageFor(shop.thumbnail),
+          ),
           SizedBox(
             height: 220,
             child: ListView(
@@ -62,7 +75,7 @@ class ShopDetail extends StatelessWidget {
                   child: Card(
                     clipBehavior: Clip.antiAlias,
                     margin: EdgeInsets.zero,
-                    child: Image.network(picture.largeUrl),
+                    child: _imageFor(picture),
                   ),
                 );
               }).toList(),


### PR DESCRIPTION
closes #1

| before | after |
|:----:|:----:|
|![before](https://user-images.githubusercontent.com/11763113/67488940-a20b4980-f6ab-11e9-8870-f87a41a8c63d.gif)| ![alwaysdrink](https://user-images.githubusercontent.com/11763113/67494219-d71b9a00-f6b3-11e9-95f4-0e24e584a839.gif)|

FadeInImageのplaceholderにsmallUrlを入れることで実現。