### PR TITLE
SET AS ALWAYSを押したときにsnackbar表示する

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,9 @@ class AlwaysDrinkApp extends StatelessWidget {
         primarySwatch: alwaysDrinkColor,
         accentColor: alwaysDrinkAccentColor,
       ),
-      home: ShopListPage(),
+      home: Scaffold(
+        body: ShopListPage(),
+      ),
     );
   }
 }
@@ -125,6 +127,13 @@ class ShopDetail extends StatelessWidget {
                   textColor: alwaysDrinkAccentColor,
                   onPressed: () {
                     _saveAlwaysShopUuid(shop.uuid);
+                    final snackBar = SnackBar(
+                      content: Text('${shop.name} が\n次回起動時からすぐ表示されます'),
+                    );
+
+                    // Find the Scaffold in the widget tree and use
+                    // it to show a SnackBar.
+                    Scaffold.of(context).showSnackBar(snackBar);
                   },
                 ),
                 const Spacer(),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -127,7 +127,7 @@ class ShopDetail extends StatelessWidget {
                   textColor: alwaysDrinkAccentColor,
                   onPressed: () {
                     _saveAlwaysShopUuid(shop.uuid);
-                    final snackBar = SnackBar(
+                    final SnackBar snackBar = SnackBar(
                       content: Text('${shop.name} が\n次回起動時からすぐ表示されます'),
                     );
 


### PR DESCRIPTION
closes #9 

ネイティブ版ではToast表示だったが、
Toastはマテリアルデザインコンポーネントに無かったため、SnackBarにした。

| Android | iOS |
|:----:|:----:|
|![alwaysdrink](https://user-images.githubusercontent.com/11763113/67777075-92717380-faa4-11e9-978a-eb77e380367a.gif) | ![alwaysdrink](https://user-images.githubusercontent.com/11763113/67777214-c187e500-faa4-11e9-9420-ab2e67302f52.gif) |
