### PR TITLE
PageViewのonPageChangedが呼ばれまくる問題に起因して設計が歪んでいたところを直す。

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -271,7 +271,7 @@ class ShopListPageState extends State {
   }
 
   void _updateSelectedShop(Shop newShop) {
-    if (selectedShop?.uuid == newShop?.uuid) {
+    if (selectedShop == newShop) {
       return;
     }
     _hideInfoWindowForSelectedShop();

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -165,6 +165,7 @@ class ShopListPageState extends State {
       Completer<GoogleMapController>();
 
   PageController _pageController;
+  bool _isPageViewAnimating;
 
   Iterable<ServiceArea> serviceAreas = <ServiceArea>[];
   List<Shop> shops = <Shop>[];
@@ -177,6 +178,7 @@ class ShopListPageState extends State {
     _pageController = PageController(
       viewportFraction: 0.95,
     );
+    _isPageViewAnimating = false;
     _fetchShopList();
   }
 
@@ -255,13 +257,23 @@ class ShopListPageState extends State {
         shops = newShops;
       });
       if (newSelectedShop != null) {
-        _setCurrentShopInPageView(newSelectedShop);
         _updateSelectedShop(newSelectedShop);
       }
     }
   }
 
+  void _updateSelectedShopForPage(int page) {
+    if (page >= 0 && page < shops.length) {
+      _updateSelectedShop(shops.elementAt(page));
+    } else {
+      _updateSelectedShop(null);
+    }
+  }
+
   void _updateSelectedShop(Shop newShop) {
+    if (selectedShop?.uuid == newShop?.uuid) {
+      return;
+    }
     _hideInfoWindowForSelectedShop();
     setState(() {
       selectedShop = newShop;
@@ -304,9 +316,25 @@ class ShopListPageState extends State {
   void _setCurrentShopInPageView(Shop target) {
     final int targetPage =
         shops.indexWhere((Shop shop) => shop.uuid == target.uuid);
-    if (targetPage >= 0 && _pageController.hasClients) {
-      _pageController.jumpToPage(targetPage);
+    if (targetPage <= 0 || !_pageController.hasClients) {
+      return;
     }
+    final int currentPage = _pageController.page.toInt();
+    if (targetPage == currentPage) {
+      return;
+    }
+
+    _isPageViewAnimating = true;
+    _pageController.animateToPage(
+      targetPage,
+      duration: Duration(milliseconds: 600),
+      curve: Curves.easeOutQuart,
+    ).then((_) {
+      // animateToPageでアニメーション途中にも通知されてしまうバグのworkaround.
+      // https://github.com/flutter/flutter/issues/43813
+      _isPageViewAnimating = false;
+      _updateSelectedShopForPage(targetPage);
+    });
   }
 
   @override
@@ -320,6 +348,9 @@ class ShopListPageState extends State {
         _showInfoWindowForSelectedShop();
       }
     });
+    if (selectedShop != null) {
+      _setCurrentShopInPageView(selectedShop);
+    }
     return Column(
       children: <Widget>[
         Expanded(
@@ -334,7 +365,7 @@ class ShopListPageState extends State {
                       : BitmapDescriptor.defaultMarkerWithHue(180),
                   infoWindow: InfoWindow(title: shop.markerTitle()),
                   onTap: () {
-                    _setCurrentShopInPageView(shop);
+                    _updateSelectedShop(shop);
                   });
             }).toSet(),
             myLocationButtonEnabled: false,
@@ -382,11 +413,12 @@ class ShopListPageState extends State {
               );
             }).toList(),
             onPageChanged: (int page) {
-              if (page >= 0 && page < shops.length) {
-                _updateSelectedShop(shops.elementAt(page));
-              } else {
-                _updateSelectedShop(null);
+              if (_isPageViewAnimating) {
+                // animateToPageでアニメーション途中にも通知されてしまうバグのworkaround.
+                // https://github.com/flutter/flutter/issues/43813
+                return;
               }
+              _updateSelectedShopForPage(page);
             },
           ),
           decoration: BoxDecoration(color: Colors.white),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -325,11 +325,12 @@ class ShopListPageState extends State {
     }
 
     _isPageViewAnimating = true;
-    _pageController.animateToPage(
+    final Future<void> onAnimateToPageComplete = _pageController.animateToPage(
       targetPage,
-      duration: Duration(milliseconds: 600),
+      duration: const Duration(milliseconds: 600),
       curve: Curves.easeOutQuart,
-    ).then((_) {
+    );
+    onAnimateToPageComplete.then((_) {
       // animateToPageでアニメーション途中にも通知されてしまうバグのworkaround.
       // https://github.com/flutter/flutter/issues/43813
       _isPageViewAnimating = false;

--- a/lib/models/picture.dart
+++ b/lib/models/picture.dart
@@ -6,4 +6,22 @@ class Picture {
 
   String smallUrl;
   String largeUrl;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+          other is Picture &&
+              runtimeType == other.runtimeType &&
+              smallUrl == other.smallUrl &&
+              largeUrl == other.largeUrl;
+
+  @override
+  int get hashCode =>
+      smallUrl.hashCode ^
+      largeUrl.hashCode;
+
+  @override
+  String toString() {
+    return 'Picture{smallUrl: $smallUrl, largeUrl: $largeUrl}';
+  }
 }

--- a/lib/models/service_area.dart
+++ b/lib/models/service_area.dart
@@ -12,4 +12,23 @@ class ServiceArea {
   String name;
   LatLng location;
   double zoom;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is ServiceArea &&
+          runtimeType == other.runtimeType &&
+          uuid == other.uuid &&
+          name == other.name &&
+          location == other.location &&
+          zoom == other.zoom;
+
+  @override
+  int get hashCode =>
+      uuid.hashCode ^ name.hashCode ^ location.hashCode ^ zoom.hashCode;
+
+  @override
+  String toString() {
+    return 'ServiceArea{uuid: $uuid, name: $name, location: $location, zoom: $zoom}';
+  }
 }

--- a/lib/models/shop.dart
+++ b/lib/models/shop.dart
@@ -48,4 +48,34 @@ class Shop {
       }
     });
   }
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Shop &&
+          runtimeType == other.runtimeType &&
+          uuid == other.uuid &&
+          name == other.name &&
+          description == other.description &&
+          roughLocationDescription == other.roughLocationDescription &&
+          businessHoursDescription == other.businessHoursDescription &&
+          location == other.location &&
+          thumbnail == other.thumbnail &&
+          pictures == other.pictures;
+
+  @override
+  int get hashCode =>
+      uuid.hashCode ^
+      name.hashCode ^
+      description.hashCode ^
+      roughLocationDescription.hashCode ^
+      businessHoursDescription.hashCode ^
+      location.hashCode ^
+      thumbnail.hashCode ^
+      pictures.hashCode;
+
+  @override
+  String toString() {
+    return 'Shop{uuid: $uuid, name: $name, description: $description, roughLocationDescription: $roughLocationDescription, businessHoursDescription: $businessHoursDescription, location: $location, thumbnail: $thumbnail, pictures: $pictures}';
+  }
 }


### PR DESCRIPTION
https://github.com/YusukeIwaki/alwaysDRINK_MyLauncher_flutter/commit/bd60fea0b9d53887e2b757ce99a46378dc6ed168 では、https://github.com/flutter/flutter/issues/43813 のワークアラウンドを見いだせていなかった。
そのときには問題回避のために、setStateをする代わりにPageViewのページを変えるような処理にしていた。

しかし、ワークアラウンドを見つけた今となっては、この設計はとても筋がよくない。

本来やるべき状態更新をやって、それによってビューが再構築される、という設計に戻す。

---

リファクタリングなので、動作は変化しない。

![alwaysdrink](https://user-images.githubusercontent.com/11763113/67947616-5ca8c800-fc27-11e9-8e28-9eac86a2e4c7.gif)

